### PR TITLE
Change to allow VD geometry

### DIFF
--- a/macros/single_muon.mac
+++ b/macros/single_muon.mac
@@ -3,6 +3,9 @@
 /run/verbose 1
 /tracking/verbose 0
 
+# The detector configuration (false  VD or true HD)
+/Geometry/DetectorConfiguration false
+
 # output path
 /Inputs/root_output ./output/single_muon.root
 
@@ -18,21 +21,39 @@
 # gamma, opticalphoton, ...
 /gps/particle mu-
 
-# point source
-/gps/pos/type Point
-/gps/pos/centre 115 475 150 cm
-
 # angular distribution
 # initial momentum in the -y direction
+#/gps/ang/type iso
+#/gps/ang/rot1 -1 0 0
+#/gps/ang/rot2 0 0 1
+#/gps/ang/mintheta 0 deg
+#/gps/ang/maxtheta 360 deg  # opening angle of cone
+
+# point source
+/gps/pos/type Point
+#Central position for a HD geometry
+#/gps/pos/centre 115 475 150 cm
+
+#Central position for a VD geometry
+/gps/pos/centre 1000 650 325 cm
+
+# angular distribution
+#/gps/ang/type iso
+#/gps/ang/rot1 -1 0 0
+#/gps/ang/rot2 0 0 1
+#/gps/ang/mintheta 0 deg
+#/gps/ang/maxtheta 0 deg  # opening angle of cone
+
+# initial momentum in the -x direction (VD configuration)
 /gps/ang/type iso
-/gps/ang/rot1 -1 0 0
-/gps/ang/rot2 0 0 1
+/gps/ang/rot1 0 0 -1
+/gps/ang/rot2 0 1 0
 /gps/ang/mintheta 0 deg
 /gps/ang/maxtheta 0 deg  # opening angle of cone
 
 # energy distribution
 /gps/ene/type Mono
-/gps/ene/mono 2 MeV
+/gps/ene/mono 2000 MeV
 
 # run
-/run/beamOn 100
+/run/beamOn 1

--- a/macros/single_muon.mac
+++ b/macros/single_muon.mac
@@ -4,7 +4,7 @@
 /tracking/verbose 0
 
 # The detector configuration (false  VD or true HD)
-/Geometry/DetectorConfiguration false
+#/Geometry/DetectorConfiguration false
 
 # output path
 /Inputs/root_output ./output/single_muon.root
@@ -32,28 +32,28 @@
 # point source
 /gps/pos/type Point
 #Central position for a HD geometry
-#/gps/pos/centre 115 475 150 cm
+/gps/pos/centre 115 475 150 cm
 
 #Central position for a VD geometry
-/gps/pos/centre 1000 650 325 cm
+#/gps/pos/centre 1000 650 325 cm
 
 # angular distribution
-#/gps/ang/type iso
-#/gps/ang/rot1 -1 0 0
-#/gps/ang/rot2 0 0 1
-#/gps/ang/mintheta 0 deg
-#/gps/ang/maxtheta 0 deg  # opening angle of cone
-
-# initial momentum in the -x direction (VD configuration)
 /gps/ang/type iso
-/gps/ang/rot1 0 0 -1
-/gps/ang/rot2 0 1 0
+/gps/ang/rot1 -1 0 0
+/gps/ang/rot2 0 0 1
 /gps/ang/mintheta 0 deg
 /gps/ang/maxtheta 0 deg  # opening angle of cone
 
+# initial momentum in the -x direction (VD configuration)
+#/gps/ang/type iso
+#/gps/ang/rot1 0 0 -1
+#/gps/ang/rot2 0 1 0
+#/gps/ang/mintheta 0 deg
+#/gps/ang/maxtheta 0 deg  # opening angle of cone
+
 # energy distribution
 /gps/ene/type Mono
-/gps/ene/mono 2000 MeV
+/gps/ene/mono 2 MeV
 
 # run
-/run/beamOn 1
+/run/beamOn 100

--- a/src/AnalysisManager.cpp
+++ b/src/AnalysisManager.cpp
@@ -43,6 +43,8 @@ void AnalysisManager::Book(std::string const file_path)
     metadata_->Branch("detector_length_x", &detector_length_x_, "detector_length_x/D");
     metadata_->Branch("detector_length_y", &detector_length_y_, "detector_length_y/D");
     metadata_->Branch("detector_length_z", &detector_length_z_, "detector_length_z/D");
+    metadata_->Branch("detector_configuration", &detectorConfiguration_);
+
 
     // event tree
     event_tree_ = new TTree("event_tree", "event tree");
@@ -215,13 +217,14 @@ void AnalysisManager::SetEvent(int const value)
 }
 
 //-----------------------------------------------------------------------------
-void AnalysisManager::FillMetadata(double const & detector_length_x,
+void AnalysisManager::FillMetadata(bool const & detectorConfiguration, double const & detector_length_x,
                                    double const & detector_length_y,
                                    double const & detector_length_z)
 {
     detector_length_x_ = detector_length_x;
     detector_length_y_ = detector_length_y;
     detector_length_z_ = detector_length_z;
+    detectorConfiguration_ = detectorConfiguration;
     metadata_->Fill();
 }
 

--- a/src/AnalysisManager.h
+++ b/src/AnalysisManager.h
@@ -41,7 +41,7 @@ class AnalysisManager {
         void SetRun(int const);
         void SetEvent(int const);
 
-        void FillMetadata(double const &, double const &, double const &);
+        void FillMetadata(bool const &, double const &, double const &, double const &);
 
         void AddInitialGeneratorParticle(GeneratorParticle const *);
         void AddFinalGeneratorParticle(GeneratorParticle const *);
@@ -70,6 +70,7 @@ class AnalysisManager {
         double detector_length_x_;
         double detector_length_y_;
         double detector_length_z_;
+        bool detectorConfiguration_;
 
         // variables that will go into the event trees
         int run_;

--- a/src/DetectorConstruction.cpp
+++ b/src/DetectorConstruction.cpp
@@ -18,18 +18,22 @@
 #include "G4SDManager.hh"
 #include "G4LogicalVolumeStore.hh"
 
-
-DetectorConstruction::DetectorConstruction(): G4VUserDetectorConstruction()
-{}
+DetectorConstruction::DetectorConstruction(): G4VUserDetectorConstruction(), detectorConfiguration(true)
+{
+  fMessenger = new G4GenericMessenger(this, "/Geometry/", "Geometry configuration");
+  fMessenger->DeclareProperty("DetectorConfiguration", detectorConfiguration, "True if HD, false if VD");
+}
 
 DetectorConstruction::~DetectorConstruction()
-{}
+{
+  delete fMessenger;
+}
 
 G4VPhysicalVolume* DetectorConstruction::Construct()
 {
   // WORLD /////////////////////////////////////////////////
 
-  G4double world_size = 15.*m;
+  G4double world_size = 30.*m;
   G4Material* world_mat = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
 
   G4Box* world_solid_vol =
@@ -42,12 +46,30 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
   G4VPhysicalVolume* world_phys_vol =
     new G4PVPlacement(0, G4ThreeVector(0.,0.,0.),
                       world_logic_vol, "world.physical", 0, false, 0, true);
+                      
 
-  // DETECTOR //////////////////////////////////////////////
+  G4double detector_width ;
+  G4double detector_height;
+  G4double detector_length;
+  
+  std::cout << " Detector configuration is: " << detectorConfiguration << std::endl;
+
+  if(detectorConfiguration)
+  {
+  // DETECTOR HD CONFIGURATION //////////////////////////////////////////////
   // resemble an APA size
-  G4double detector_width   = 2.3*m;
-  G4double detector_height  = 6.0*m;
-  G4double detector_length  = 3.6*m;
+    detector_width   = 2.3*m;
+    detector_height  = 6.0*m;
+    detector_length  = 3.6*m;
+  }
+  else
+  {
+  // DETECTOR VD CONFIGURATION //////////////////////////////////////////////
+    detector_height = 13.0*m;
+    detector_length = 6.5*m;
+    detector_width = 20.0*m;
+  }
+
   G4Material* detector_mat = G4NistManager::Instance()->FindOrBuildMaterial("G4_lAr");
 
   G4Box* detector_solid_vol =
@@ -60,7 +82,6 @@ G4VPhysicalVolume* DetectorConstruction::Construct()
 
   new G4PVPlacement(0, offset,
                     detector_logic_vol, "detector.physical", world_logic_vol, false, 0, true);
-
   //////////////////////////////////////////////////////////
 
   return world_phys_vol;

--- a/src/DetectorConstruction.h
+++ b/src/DetectorConstruction.h
@@ -10,7 +10,7 @@
 #define DETECTOR_CONSTRUCTION_H 1
 
 #include "G4VUserDetectorConstruction.hh"
-
+#include "G4GenericMessenger.hh"
 class G4Material;
 
 
@@ -19,9 +19,13 @@ class DetectorConstruction: public G4VUserDetectorConstruction
 public:
   DetectorConstruction();
   virtual ~DetectorConstruction();
+  bool GetDetectorConfiguration() const { return detectorConfiguration;}
+
 private:
   virtual G4VPhysicalVolume* Construct();
   virtual void ConstructSDandField();
+  G4GenericMessenger *fMessenger;
+  bool detectorConfiguration;
 };
 
 #endif

--- a/src/RunAction.cpp
+++ b/src/RunAction.cpp
@@ -12,11 +12,14 @@
 #include "AnalysisManager.h"
 #include "MARLEYManager.h"
 #include "MCTruthManager.h"
+#include "DetectorConstruction.h"
 
 // GEANT4 includes
 #include "G4Box.hh"
 #include "G4LogicalVolumeStore.hh"
 #include "G4Run.hh"
+#include "G4RunManager.hh"
+#include "G4VUserDetectorConstruction.hh"
 
 // C++ includes
 #include <filesystem>
@@ -124,8 +127,13 @@ void RunAction::EndOfRunAction(const G4Run*)
       //                         << detector_length_z << " cm"
       //        << G4endl;
 
+      G4RunManager* rm = G4RunManager::GetRunManager(); // Get the run manager to access the detector construction
+      const G4VUserDetectorConstruction* baseDetCons = rm->GetUserDetectorConstruction();
+      const DetectorConstruction* detCons = dynamic_cast<const DetectorConstruction*>(baseDetCons); // Get our user-defined detector construction
+      const bool detectorConfiguration = detCons->GetDetectorConfiguration(); // Retrieve the detector configuration
+
       // save detector dimensions as metadata
-      analysis_manager->FillMetadata(detector_length_x,
+      analysis_manager->FillMetadata(detectorConfiguration, detector_length_x,
                                      detector_length_y,
                                      detector_length_z);
     }


### PR DESCRIPTION
Change the detector geometry to allow a VD-like configuration. Add the boolean variable `detectorConfiguration` to keep track of the geometry choice. Also add some lines to `single_muon.mac` to change particle direction and initial position for the new detector geometry.

Presented @ QPix Simulation Meeting 10/06. 