### PR TITLE
V3.0.0 cvmfs fixes + Geant4 V4.11.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,10 @@ include(${ROOT_USE_FILE})
 ## link ROOT libraries
 link_libraries(${ROOT_LIBRARIES})
 
+## MARLEY includes and libraries
+include_directories($ENV{MARLEY_INC})
+link_directories($ENV{MARLEY_LIB})
+
 ## Recurse through sub-directories
 add_subdirectory(src)
 add_subdirectory(app)

--- a/app/G4_QPIX.cpp
+++ b/app/G4_QPIX.cpp
@@ -13,6 +13,7 @@
 #include "EventAction.h"
 #include "PrimaryGeneration.h"
 #include "GENIEManager.h"
+#include "PhysicsList.h"
 #include "RunAction.h"
 #include "SteppingAction.h"
 #include "TrackingAction.h"
@@ -39,7 +40,8 @@
 int main(int argc, char** argv)
 {
 
-  ConfigManager::Instance();
+  auto* config = ConfigManager::Instance();
+  config->PrintConfig();
   //choose the Random engine
   CLHEP::HepRandom::setTheEngine(new CLHEP::RanecuEngine());
   //set random seed with system time
@@ -55,9 +57,10 @@ int main(int argc, char** argv)
   // Construct the run manager and set the initialization classes
   auto* run_manager = G4RunManagerFactory::CreateRunManager(G4RunManagerType::Default);
 
-  G4VModularPhysicsList* physics_list = new FTFP_BERT_HP();
-  physics_list->ReplacePhysics(new G4EmStandardPhysics_option4());
-  run_manager->SetUserInitialization(physics_list);
+  // G4VModularPhysicsList* physics_list = new FTFP_BERT_HP();
+  // physics_list->ReplacePhysics(new G4EmStandardPhysics_option4());
+  // run_manager->SetUserInitialization(physics_list);
+  run_manager->SetUserInitialization(new PhysicsList());
 
   run_manager->SetUserInitialization(new DetectorConstruction());
   run_manager->SetUserInitialization(new ActionInitialization());

--- a/macros/Template_IonGun_Radioactive.macro
+++ b/macros/Template_IonGun_Radioactive.macro
@@ -4,7 +4,7 @@
 /tracking/verbose 0
 
 # output path
-/inputs/root_output ./output/Radioactive.root
+/inputs/output_file ./output/Radioactive.root
 
 # make unstable isotopes decay at t=0
 /inputs/decay_at_time_zero true  # this is set to false by default

--- a/macros/Template_IonGun_Radioactive.macro
+++ b/macros/Template_IonGun_Radioactive.macro
@@ -4,14 +4,14 @@
 /tracking/verbose 0
 
 # output path
-/Inputs/root_output ./output/Radioactive.root
+/inputs/root_output ./output/Radioactive.root
 
 # make unstable isotopes decay at t=0
-/Inputs/decay_at_time_zero true  # this is set to false by default
+/inputs/decay_at_time_zero true  # this is set to false by default
 
 # limit radioactive decay chains
 # use if needed
-#/grdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
+#/process/had/rdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
 
 # initialize run
 /run/initialize

--- a/macros/Template_Marley.mac
+++ b/macros/Template_Marley.mac
@@ -21,7 +21,7 @@
 /random/setSeeds 0 31
 
 # limit radioactive decays 
-/process/had/rdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
+#/process/had/rdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
 
 # run
 /run/beamOn 100

--- a/macros/Template_Marley.mac
+++ b/macros/Template_Marley.mac
@@ -4,23 +4,24 @@
 /tracking/verbose 0
 
 # configure marley
-/Inputs/Particle_Type MARLEY
-/Inputs/MARLEY_json ../cfg/marley_config.js
-/Inputs/isotropic false
-/Inputs/override_vertex_position false
-/Inputs/vertex_x 1.15 m
-/Inputs/vertex_y 3.0 m
-/Inputs/vertex_z 1.8 m
+/inputs/generator MARLEY
+/inputs/particle_type MARLEY
+/inputs/MARLEY_json ../cfg/marley_config.js
+/inputs/isotropic false
+/inputs/override_vertex_position false
+/inputs/vertex_x 1.15 m
+/inputs/vertex_y 3.0 m
+/inputs/vertex_z 1.8 m
 
 # output path
-/Inputs/root_output ../output/MARLEY.root
+/inputs/root_output ../output/MARLEY.root
 
 # initialize run
 /run/initialize
 /random/setSeeds 0 31
 
 # limit radioactive decays 
-/grdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
+/process/had/rdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
 
 # run
 /run/beamOn 100

--- a/macros/Template_Marley.mac
+++ b/macros/Template_Marley.mac
@@ -14,7 +14,7 @@
 /inputs/vertex_z 1.8 m
 
 # output path
-/inputs/root_output ../output/MARLEY.root
+/inputs/output_file ../output/MARLEY.root
 
 # initialize run
 /run/initialize

--- a/macros/Template_ParticleGun_Plane.macro
+++ b/macros/Template_ParticleGun_Plane.macro
@@ -4,7 +4,7 @@
 /tracking/verbose 0
 
 # output path
-/inputs/root_output ../output/muon.root
+/inputs/output_file ../output/muon.root
 
 # initialize run
 /run/initialize

--- a/macros/Template_ParticleGun_Plane.macro
+++ b/macros/Template_ParticleGun_Plane.macro
@@ -4,7 +4,7 @@
 /tracking/verbose 0
 
 # output path
-/Inputs/root_output ../output/muon.root
+/inputs/root_output ../output/muon.root
 
 # initialize run
 /run/initialize

--- a/macros/Template_ParticleGun_Sphere.macro
+++ b/macros/Template_ParticleGun_Sphere.macro
@@ -4,7 +4,7 @@
 /tracking/verbose 0
 
 # output path
-/inputs/root_output ../output/proton.root
+/inputs/output_file ../output/proton.root
 
 # initialize run
 /run/initialize

--- a/macros/Template_ParticleGun_Sphere.macro
+++ b/macros/Template_ParticleGun_Sphere.macro
@@ -4,7 +4,7 @@
 /tracking/verbose 0
 
 # output path
-/Inputs/root_output ../output/proton.root
+/inputs/root_output ../output/proton.root
 
 # initialize run
 /run/initialize
@@ -12,7 +12,7 @@
 
 # limit radioactive decay chains
 # use if needed
-#/grdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
+#/process/had/rdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
 
 # particle type
 # e-, e+, mu-, mu+, neutron, proton, anti_proton, pi-, pi+, pi0, kaon-, kaon+,

--- a/macros/Template_Supernova_Background.mac
+++ b/macros/Template_Supernova_Background.mac
@@ -7,7 +7,7 @@
 /inputs/particle_type SUPERNOVA
 
 # output path
-/inputs/root_output ../output/SUPERNOVA_BACKGROUND.root
+/inputs/output_file ../output/SUPERNOVA_BACKGROUND.root
 
 # initialize run
 /run/initialize

--- a/macros/Template_Supernova_Background.mac
+++ b/macros/Template_Supernova_Background.mac
@@ -4,10 +4,10 @@
 /tracking/verbose 0
 
 # configure supernova
-/Inputs/Particle_Type SUPERNOVA
+/inputs/particle_type SUPERNOVA
 
 # output path
-/Inputs/root_output ../output/SUPERNOVA_BACKGROUND.root
+/inputs/root_output ../output/SUPERNOVA_BACKGROUND.root
 
 # initialize run
 /run/initialize
@@ -15,19 +15,19 @@
 
 
 # Supernova configs
-/Supernova/Event_Window 10 s
-/Supernova/Event_Cutoff 10 s
+/supernova/Event_Window 10 s
+/supernova/Event_Cutoff 10 s
 
-/Supernova/N_Ar39_Decays 707000
-/Supernova/N_Ar42_Decays 64
-/Supernova/N_Bi214_Decays 7000
-/Supernova/N_Co60_Decays 41
-/Supernova/N_K40_Decays 12642
-/Supernova/N_K42_Decays 64
-/Supernova/N_Kr85_Decays 80500
-/Supernova/N_Pb214_Decays 7000
-/Supernova/N_Po210_Decays 5
-/Supernova/N_Rn222_Decays 27740
+/supernova/N_Ar39_Decays 707000
+/supernova/N_Ar42_Decays 64
+/supernova/N_Bi214_Decays 7000
+/supernova/N_Co60_Decays 41
+/supernova/N_K40_Decays 12642
+/supernova/N_K42_Decays 64
+/supernova/N_Kr85_Decays 80500
+/supernova/N_Pb214_Decays 7000
+/supernova/N_Po210_Decays 5
+/supernova/N_Rn222_Decays 27740
 
 # run
 /run/beamOn 100

--- a/macros/Template_Supernova_Neutrino.mac
+++ b/macros/Template_Supernova_Neutrino.mac
@@ -4,13 +4,14 @@
 /tracking/verbose 0
 
 # configure marley for supernova
-/Inputs/Particle_Type MARLEY
-/Inputs/MARLEY_json ../cfg/marley_config_supernova.js
-/Inputs/isotropic false
-/Inputs/override_vertex_position false
-/Inputs/vertex_x 1.15 m
-/Inputs/vertex_y 3.0 m
-/Inputs/vertex_z 1.8 m
+/inputs/generator MARLEY
+/inputs/particle_type MARLEY
+/inputs/MARLEY_json ../cfg/marley_config_supernova.js
+/inputs/isotropic false
+/inputs/override_vertex_position false
+/inputs/vertex_x 1.15 m
+/inputs/vertex_y 3.0 m
+/inputs/vertex_z 1.8 m
 
 # configure supernova timing
 /supernova/timing/on         true
@@ -18,14 +19,14 @@
 /supernova/timing/th2_name   nusperbin2d_nue
 
 # output path
-/Inputs/root_output ../output/SUPERNOVA_NEUTRINO.root
+/inputs/root_output ../output/SUPERNOVA_NEUTRINO.root
 
 # initialize run
 /run/initialize
 /random/setSeeds 0 31
 
 # Supernova configs
-/Supernova/Event_Cutoff 10 s
+/supernova/Event_Cutoff 10 s
 
 # limit radioactive decays 
 /grdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax

--- a/macros/Template_Supernova_Neutrino.mac
+++ b/macros/Template_Supernova_Neutrino.mac
@@ -19,7 +19,7 @@
 /supernova/timing/th2_name   nusperbin2d_nue
 
 # output path
-/inputs/root_output ../output/SUPERNOVA_NEUTRINO.root
+/inputs/output_file ../output/SUPERNOVA_NEUTRINO.root
 
 # initialize run
 /run/initialize

--- a/macros/single_electron.mac
+++ b/macros/single_electron.mac
@@ -4,7 +4,7 @@
 /tracking/verbose 0
 
 # output path
-/inputs/root_output ./output/single_electron.root
+/inputs/output_file ./output/single_electron.root
 
 # initialize run
 /run/initialize

--- a/macros/single_electron.mac
+++ b/macros/single_electron.mac
@@ -4,14 +4,14 @@
 /tracking/verbose 0
 
 # output path
-/Inputs/root_output ./output/single_electron.root
+/inputs/root_output ./output/single_electron.root
 
 # initialize run
 /run/initialize
 /random/setSeeds 0 31
 
 # limit radioactive decays
-#/grdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
+#/process/had/rdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
 
 # particle type
 # e-, e+, mu-, mu+, neutron, proton, anti_proton, pi-, pi+, pi0, kaon-, kaon+,

--- a/macros/single_muon.mac
+++ b/macros/single_muon.mac
@@ -14,7 +14,7 @@
 /random/setSeeds 0 31
 
 # limit radioactive decays
-#/grdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
+#/process/had/rdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
 
 # particle type
 # e-, e+, mu-, mu+, neutron, proton, anti_proton, pi-, pi+, pi0, kaon-, kaon+,

--- a/macros/single_pion.mac
+++ b/macros/single_pion.mac
@@ -4,7 +4,7 @@
 /tracking/verbose 0
 
 # output path
-/inputs/root_output ./output/single_pion.root
+/inputs/output_file ./output/single_pion.root
 
 # initialize run
 /run/initialize

--- a/macros/single_pion.mac
+++ b/macros/single_pion.mac
@@ -4,14 +4,14 @@
 /tracking/verbose 0
 
 # output path
-/Inputs/root_output ./output/single_pion.root
+/inputs/root_output ./output/single_pion.root
 
 # initialize run
 /run/initialize
 /random/setSeeds 0 31
 
 # limit radioactive decays
-#/grdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
+#/process/had/rdm/nucleusLimits 1 35 1 17  # aMin aMax zMin zMax
 
 # particle type
 # e-, e+, mu-, mu+, neutron, proton, anti_proton, pi-, pi+, pi0, kaon-, kaon+,

--- a/setup/setup_cvmfs.sh
+++ b/setup/setup_cvmfs.sh
@@ -7,7 +7,12 @@ setup mrb
 setup cmake  v3_20_0
 setup boost  v1_75_0      -q e20:prof
 setup root   v6_22_08d    -q e20:p392:prof
-setup geant4 v4_10_6_p01d -q e20:prof
 setup marley v1_2_0e      -q e20:prof
 
-cd ${MARLEY}/marley-`marley-config --version`/build && source ${MARLEY}/marley-`marley-config --version`/setup_marley.sh && cd ${OLDPWD}
+pushd ${MARLEY}/marley-`marley-config --version`/build
+source ${MARLEY}/marley-`marley-config --version`/setup_marley.sh
+popd
+
+pushd /cvmfs/geant4.cern.ch/geant4/10.7.p04a/x86_64-centos7-gcc9-optdeb-MT/share/Geant4-10.7.4/geant4make/
+source geant4make.sh
+popd

--- a/setup/setup_cvmfs.sh
+++ b/setup/setup_cvmfs.sh
@@ -6,13 +6,13 @@ setup git
 setup mrb
 setup cmake  v3_20_0
 setup boost  v1_75_0      -q e20:prof
-setup root   v6_22_08d    -q e20:p392:prof
+setup root   v6_26_06b    -q e20:p3913:prof
 setup marley v1_2_0e      -q e20:prof
-
-pushd ${MARLEY}/marley-`marley-config --version`/build
-source ${MARLEY}/marley-`marley-config --version`/setup_marley.sh
-popd
 
 pushd /cvmfs/geant4.cern.ch/geant4/10.7.p04a/x86_64-centos7-gcc9-optdeb-MT/share/Geant4-10.7.4/geant4make/
 source geant4make.sh
+popd
+
+pushd ${MARLEY}/marley-`marley-config --version`/build
+source ${MARLEY}/marley-`marley-config --version`/setup_marley.sh
 popd

--- a/src/AnalysisData.h
+++ b/src/AnalysisData.h
@@ -10,7 +10,8 @@
 #define AnalysisData_h 1
 
 // GEANT4 includes
-#include "globals.hh"
+// #include "globals.hh"
+#include </cvmfs/larsoft.opensciencegrid.org/products/geant4/v4_11_1_p01ba/Linux64bit+3.10-2.17-e20-prof/include/Geant4/globals.hh>
 
 // ROOT includes
 #include "Rtypes.h"

--- a/src/AnalysisManager.h
+++ b/src/AnalysisManager.h
@@ -12,8 +12,8 @@
 // Qpix includes
 #include "AnalysisData.h"
 
-// GEANT4 includes
-#include "globals.hh"
+// // GEANT4 includes
+// #include </cvmfs/larsoft.opensciencegrid.org/products/geant4/v4_11_1_p01ba/Linux64bit+3.10-2.17-e20-prof/include/Geant4/globals.hh>
 
 // C++ includes
 #include <map>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ SET(SRC   ActionInitialization.cpp
           MARLEYManager.cpp
           MCTruthManager.cpp
           MCParticle.cpp
+          PhysicsList.cpp
           PrimaryGeneration.cpp
           RunAction.cpp
           SteppingAction.cpp

--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -48,7 +48,7 @@ ConfigManager::ConfigManager()
   overrideVertexPosition_(false), printParticleInfo_(false), inputFile_(""), outputFile_(""), marleyJson_(""), generator_(""),
   genieFormat_(""), multirun_(false), momentumDirection_(0,0,0), vertexX_(2.3*CLHEP::m/2), vertexY_(6.0*CLHEP::m/2), vertexZ_(3.7*CLHEP::m/2),
   nAr39Decays_(0), nAr42Decays_(0), nKr85Decays_(0), nCo60Decays_(0), nK40Decays_(0),
-  nK42Decays_(0), nBi214Decays_(0), nPb214Decays_(0), nPo210Decays_(0), nRn222Decays_(0), eventCutoff_(0),
+  nK42Decays_(0), nBi214Decays_(0), nPb214Decays_(0), nPo210Decays_(0), nPo214Decays_(0), nPo218Decays_(0), nRn222Decays_(0), eventCutoff_(0),
   eventWindow_(0),
   snTimingOn_(false), th2Name_("nusperbin2d_nue"),
   useHDDetectorConfiguration_(true), detectorLength_(0), detectorWidth_(0), detectorHeight_(0)
@@ -73,7 +73,7 @@ ConfigManager::ConfigManager(const ConfigManager& master)
   nKr85Decays_(master.nKr85Decays_), nCo60Decays_(master.nCo60Decays_),
   nK40Decays_(master.nK40Decays_), nK42Decays_(master.nK42Decays_),
   nBi214Decays_(master.nBi214Decays_), nPb214Decays_(master.nPb214Decays_),
-  nPo210Decays_(master.nPo210Decays_), nRn222Decays_(master.nRn222Decays_),
+  nPo210Decays_(master.nPo210Decays_), nPo214Decays_(master.nPo214Decays_), nPo218Decays_(master.nPo218Decays_), nRn222Decays_(master.nRn222Decays_),
   eventCutoff_(master.eventCutoff_), eventWindow_(master.eventWindow_),
   snTimingOn_(master.snTimingOn_), th2Name_(master.th2Name_),
   useHDDetectorConfiguration_(master.useHDDetectorConfiguration_), detectorLength_(master.detectorLength_),
@@ -134,6 +134,8 @@ void ConfigManager::CreateCommands()
   msgSupernova_->DeclareProperty("N_Bi214_Decays", nBi214Decays_,  "number of Bi214 decays");
   msgSupernova_->DeclareProperty("N_Pb214_Decays", nPb214Decays_,  "number of Pb214 decays");
   msgSupernova_->DeclareProperty("N_Po210_Decays", nPo210Decays_,  "number of Po210 decays");
+  msgSupernova_->DeclareProperty("N_Po214_Decays", nPo214Decays_,  "number of Po214 decays");
+  msgSupernova_->DeclareProperty("N_Po218_Decays", nPo218Decays_,  "number of Po218 decays");
   msgSupernova_->DeclareProperty("N_Rn222_Decays", nRn222Decays_,  "number of Rn222 decays");
 
   msgSupernova_->DeclarePropertyWithUnit("Event_Cutoff", "ns", eventCutoff_,  "window to simulate the times");
@@ -181,6 +183,8 @@ void ConfigManager::PrintConfig() const
      << "Supernova -- N_Bi214_Decays: " << nBi214Decays_ << G4endl
      << "Supernova -- N_Pb214_Decays: " << nPb214Decays_ << G4endl
      << "Supernova -- N_Po210_Decays: " << nPo210Decays_ << G4endl
+     << "Supernova -- N_Po214_Decays: " << nPo214Decays_ << G4endl
+     << "Supernova -- N_Po218_Decays: " << nPo218Decays_ << G4endl
      << "Supernova -- N_Rn222_Decays: " << nRn222Decays_ << G4endl
      << "Supernova -- Event_Cutoff:   " << eventCutoff_/CLHEP::ns << " ns" << G4endl
      << "Supernova -- Event_Window:   " << eventWindow_/CLHEP::ns << " ns" << G4endl

--- a/src/ConfigManager.h
+++ b/src/ConfigManager.h
@@ -1,200 +1,179 @@
 // -----------------------------------------------------------------------------
-//  ConfigManager.cpp
+//  G4_QPIX | ConfigManager.h
 //
-//  Class definition of the ConfigManager Singleton Container
+//
 //   * Author: Everybody is an author!
-//   * Creation date: 18 November 2022
+//   * Creation date: 18 Nov 2022
 // -----------------------------------------------------------------------------
 
+#ifndef CONFIG_MANAGER_H
+#define CONFIG_MANAGER_H 
+
 // Class Includes
-#include "ConfigManager.h"
+
+// Package Includes
 
 // Geant Includes
-#include "globals.hh"
-#include "G4GenericMessenger.hh"
-#include "G4Threading.hh"
+#include "G4Types.hh"
+#include "G4String.hh"
 #include "G4ThreeVector.hh"
-#include "CLHEP/Units/SystemOfUnits.h"
 
 // System Includes
-#include <fstream>
-#include <iostream>
-#include <typeinfo>
-#include <float.h>
-#include <stdlib.h>
 
-//-----------------------------------------------------------------------------
-// Singleton Initializers for master and worker threads
-ConfigManager* ConfigManager::Instance() {
-  static const ConfigManager* masterInstance = 0;
-  static G4ThreadLocal ConfigManager* theInstance = 0;
+// Forward Declarations
+class G4GenericMessenger;
 
-  if (!theInstance) {
-    if (!G4Threading::IsWorkerThread()) {   // Master or sequential
-      theInstance = new ConfigManager;
-      masterInstance = theInstance;
-    } else {                    // Workers copy from master
-      theInstance = new ConfigManager(*masterInstance);
-    }
-  }
 
-  return theInstance;
-}
+class ConfigManager {
+  public:
 
-//-----------------------------------------------------------------------------
-ConfigManager::ConfigManager()
-  : eventIDOffset_(0), energyThreshold_(0),
-  particleType_(""), decayAtTimeZero_(false), isotropic_(true),
-  overrideVertexPosition_(false), printParticleInfo_(false), inputFile_(""), outputFile_(""), marleyJson_(""), generator_(""),
-  genieFormat_(""), multirun_(false), momentumDirection_(0,0,0), vertexX_(2.3*CLHEP::m/2), vertexY_(6.0*CLHEP::m/2), vertexZ_(3.7*CLHEP::m/2),
-  nAr39Decays_(0), nAr42Decays_(0), nKr85Decays_(0), nCo60Decays_(0), nK40Decays_(0),
-  nK42Decays_(0), nBi214Decays_(0), nPb214Decays_(0), nPo210Decays_(0), nPo214Decays_(0), nPo218Decays_(0), nRn222Decays_(0), eventCutoff_(0),
-  eventWindow_(0),
-  snTimingOn_(false), th2Name_("nusperbin2d_nue"),
-  useHDDetectorConfiguration_(true), detectorLength_(0), detectorWidth_(0), detectorHeight_(0)
-{
-  CreateCommands();
-}
+    // Thread-specific instance for use with Get/Set functions
+    static ConfigManager* Instance();
 
-//-----------------------------------------------------------------------------
-ConfigManager::ConfigManager(const ConfigManager& master)
-  : eventIDOffset_(master.eventIDOffset_),
-  energyThreshold_(master.energyThreshold_),
-  particleType_(master.particleType_),
-  decayAtTimeZero_(master.decayAtTimeZero_), isotropic_(master.isotropic_),
-  overrideVertexPosition_(master.overrideVertexPosition_),
-  printParticleInfo_(master.printParticleInfo_), inputFile_(master.inputFile_),
-  outputFile_(master.outputFile_), marleyJson_(master.marleyJson_),
-  generator_(master.generator_), genieFormat_(master.genieFormat_),
-  multirun_(master.multirun_), momentumDirection_(master.momentumDirection_),
-  vertexX_(master.vertexX_), vertexY_(master.vertexY_),
-  vertexZ_(master.vertexZ_),
-  nAr39Decays_(master.nAr39Decays_), nAr42Decays_(master.nAr42Decays_),
-  nKr85Decays_(master.nKr85Decays_), nCo60Decays_(master.nCo60Decays_),
-  nK40Decays_(master.nK40Decays_), nK42Decays_(master.nK42Decays_),
-  nBi214Decays_(master.nBi214Decays_), nPb214Decays_(master.nPb214Decays_),
-  nPo210Decays_(master.nPo210Decays_), nPo214Decays_(master.nPo214Decays_), nPo218Decays_(master.nPo218Decays_), nRn222Decays_(master.nRn222Decays_),
-  eventCutoff_(master.eventCutoff_), eventWindow_(master.eventWindow_),
-  snTimingOn_(master.snTimingOn_), th2Name_(master.th2Name_),
-  useHDDetectorConfiguration_(master.useHDDetectorConfiguration_), detectorLength_(master.detectorLength_),
-  detectorWidth_(master.detectorWidth_), detectorHeight_(master.detectorHeight_)
-{
-  CreateCommands();
-}
+    ConfigManager();
+    ConfigManager(const ConfigManager&);
+    ~ConfigManager();
+    
+    void CreateCommands();
 
-//-----------------------------------------------------------------------------
-ConfigManager::~ConfigManager()
-{
-  delete msgEvent_;
-  delete msgInputs_;
-  delete msgSupernova_;
-  delete msgSupernovaTiming_;
-  delete msgGeometry_;
-}
 
-//-----------------------------------------------------------------------------
-void ConfigManager::CreateCommands()
-{
-  // Instantiate all messengers
-  msgEvent_ = new G4GenericMessenger(this, "/event/", "user-defined event configuration");
-  msgInputs_ = new G4GenericMessenger(this, "/inputs/", "Control commands of the ion primary generator.");
-  msgSupernova_ = new G4GenericMessenger(this, "/supernova/", "Control commands of the supernova generator.");
-  msgSupernovaTiming_ = new G4GenericMessenger(this, "/supernova/timing/", "control commands for SupernovaTiming");
-  msgGeometry_ = new G4GenericMessenger(this, "/geometry/", "control commands for DetectorConstruction");
+    // Access current values
+    static G4int         GetEventIDOffset()                 { return Instance()->eventIDOffset_; }
+    static G4double      GetEnergyThreshold()               { return Instance()->energyThreshold_; }
+    static G4String      GetParticleType()                  { return Instance()->particleType_; }
+    static G4bool        GetDecayAtTimeZero()               { return Instance()->decayAtTimeZero_; }
+    static G4bool        GetIsotropic()                     { return Instance()->isotropic_; }
+    static G4bool        GetOverrideVertexPosition()        { return Instance()->overrideVertexPosition_; }
+    static G4bool        GetPrintParticleInfo()             { return Instance()->printParticleInfo_; }
+    static G4String      GetInputFile()                     { return Instance()->inputFile_; }
+    static G4String      GetOutputFile()                    { return Instance()->outputFile_; }
+    static G4String      GetMarleyJson()                    { return Instance()->marleyJson_; }
+    static G4String      GetGenerator()                     { return Instance()->generator_; }
+    static G4String      GetGenieFormat()                   { return Instance()->genieFormat_; }
+    static G4bool        GetMultirun()                      { return Instance()->multirun_; }
+    static G4ThreeVector GetMomentumDirection()             { return Instance()->momentumDirection_; }
+    static G4double      GetVertexX()                       { return Instance()->vertexX_; }
+    static G4double      GetVertexY()                       { return Instance()->vertexY_; }
+    static G4double      GetVertexZ()                       { return Instance()->vertexZ_; }
+    static G4int         GetNAr39Decays()                   { return Instance()->nAr39Decays_; }
+    static G4int         GetNAr42Decays()                   { return Instance()->nAr42Decays_; }
+    static G4int         GetNKr85Decays()                   { return Instance()->nKr85Decays_; }
+    static G4int         GetNCo60Decays()                   { return Instance()->nCo60Decays_; }
+    static G4int         GetNK40Decays()                    { return Instance()->nK40Decays_; }
+    static G4int         GetNK42Decays()                    { return Instance()->nK42Decays_; }
+    static G4int         GetNBi214Decays()                  { return Instance()->nBi214Decays_; }
+    static G4int         GetNPb214Decays()                  { return Instance()->nPb214Decays_; }
+    static G4int         GetNPo210Decays()                  { return Instance()->nPo210Decays_; }
+    static G4int         GetNPo214Decays()                  { return Instance()->nPo214Decays_; }
+    static G4int         GetNPo218Decays()                  { return Instance()->nPo218Decays_; }
+    static G4int         GetNRn222Decays()                  { return Instance()->nRn222Decays_; }
+    static G4double      GetEventCutoff()                   { return Instance()->eventCutoff_; }
+    static G4double      GetEventWindow()                   { return Instance()->eventWindow_; }
+    static G4bool        GetSNTimingOn()                    { return Instance()->snTimingOn_; }
+    static G4String      GetTh2Name()                       { return Instance()->th2Name_; }
+    static G4bool        GetUseHDDetectorConfiguration()    { return Instance()->useHDDetectorConfiguration_; }
+    static G4double      GetDetectorLength()                { return Instance()->detectorLength_; }
+    static G4double      GetDetectorWidth()                 { return Instance()->detectorWidth_; }
+    static G4double      GetDetectorHeight()                { return Instance()->detectorHeight_; }
 
-  // Declare all properties for msgEvent
-  msgEvent_->DeclareProperty("offset", eventIDOffset_, "Event ID offset.");
-  msgEvent_->DeclarePropertyWithUnit("energy_threshold", "MeV", energyThreshold_, "Events that deposit less energy than this energy threshold will not be saved.");
+    // Change values (e.g. via Messenger) -- pass strings by value for toLower()
+    static void SetEventIDOffset(G4int value)               { Instance()->eventIDOffset_ = value; }
+    static void SetEnergyThreshold(G4double value)          { Instance()->energyThreshold_ = value; }
+    static void SetParticleType(G4String value)             { Instance()->particleType_ = value; }
+    static void SetDecayAtTimeZero(G4bool value)            { Instance()->decayAtTimeZero_ = value; }
+    static void SetIsotropic(G4bool value)                  { Instance()->isotropic_ = value; }
+    static void SetOverrideVertexPosition(G4bool value)     { Instance()->overrideVertexPosition_ = value; }
+    static void SetPrintParticleInfo(G4bool value)          { Instance()->printParticleInfo_ = value; }
+    static void SetInputFile(G4String value)                { Instance()->inputFile_ = value; }
+    static void SetOutputFile(G4String value)               { Instance()->outputFile_= value; }
+    static void SetMarleyJson(G4String value)               { Instance()->marleyJson_= value; }
+    static void SetGenerator(G4String value)                { Instance()->generator_ = value; }
+    static void SetGenieFormat(G4String value)              { Instance()->genieFormat_ = value; }
+    static void SetMultirun(G4bool value)                   { Instance()->multirun_ = value; }
+    static void SetMomentumDirection(G4ThreeVector value)   { Instance()->momentumDirection_ = value; }
+    static void SetVertexX(G4double value)                  { Instance()->vertexX_ = value; }
+    static void SetVertexY(G4double value)                  { Instance()->vertexY_ = value; }
+    static void SetVertexZ(G4double value)                  { Instance()->vertexZ_ = value; }
+    static void SetNAr39Decays(G4int value)                 { Instance()->nAr39Decays_ = value; }
+    static void SetNAr42Decays(G4int value)                 { Instance()->nAr42Decays_ = value; }
+    static void SetNKr85Decays(G4int value)                 { Instance()->nKr85Decays_ = value; }
+    static void SetNCo60Decays(G4int value)                 { Instance()->nCo60Decays_ = value; }
+    static void SetNK40Decays(G4int value)                  { Instance()->nK40Decays_ = value; }
+    static void SetNK42Decays(G4int value)                  { Instance()->nK42Decays_ = value; }
+    static void SetNBi214Decays(G4int value)                { Instance()->nBi214Decays_ = value; }
+    static void SetNPb214Decays(G4int value)                { Instance()->nPb214Decays_ = value; }
+    static void SetNPo210Decays(G4int value)                { Instance()->nPo210Decays_ = value; }
+    static void SetNPo214Decays(G4int value)                { Instance()->nPo214Decays_ = value; }
+    static void SetNPo218Decays(G4int value)                { Instance()->nPo218Decays_ = value; }
+    static void SetNRn222Decays(G4int value)                { Instance()->nRn222Decays_ = value; }
+    static void SetEventCutoff(G4double value)              { Instance()->eventCutoff_ = value; }
+    static void SetEventWindow(G4double value)              { Instance()->eventWindow_ = value; }
+    static void SetSNTimingOn(G4bool value)                 { Instance()->snTimingOn_ = value; }
+    static void SetTh2Name(G4String value)                  { Instance()->th2Name_ = value; }            
+    static void SetUseHDDetectorConfiguration(G4bool value) { Instance()->useHDDetectorConfiguration_ = value; }
+    static void SetDetectorLength(G4double value)           { Instance()->detectorLength_ = value; }
+    static void SetDetectorWidth(G4double value)            { Instance()->detectorWidth_ = value; }
+    static void SetDetectorHeight(G4double value)           { Instance()->detectorHeight_ = value; }
 
-  // Declare all properties for msgInputs
-  msgInputs_->DeclareProperty("particle_type", particleType_,  "which kind of particle?");
-  msgInputs_->DeclareProperty("decay_at_time_zero", decayAtTimeZero_, "Set to true to make unstable isotopes decay at t=0.");
-  msgInputs_->DeclareProperty("isotropic", isotropic_, "isotropic");
-  msgInputs_->DeclareProperty("override_vertex_position", overrideVertexPosition_, "override vertex position");
-  msgInputs_->DeclareProperty("print_particle_info", printParticleInfo_, "Extra Printing for Debugging");
-  msgInputs_->DeclareProperty("input_file", inputFile_, "input ROOT file");
-  msgInputs_->DeclareProperty("output_file", outputFile_, "output ROOT file");
-  msgInputs_->DeclareProperty("MARLEY_json", marleyJson_, "marley config json file");
-  msgInputs_->DeclareProperty("generator", generator_, "event generator of input file");
-  msgInputs_->DeclareProperty("multirun", multirun_, "multiple runs");
-  msgInputs_->DeclareProperty("genie_format", genieFormat_, "format of genie-produced input file");
-  msgInputs_->DeclareProperty("momentum_direction", momentumDirection_, "initial momentum of generator particles");
+    // Print out all configuration settings
+    static void Print() { Instance()->PrintConfig(); }
+    void PrintConfig() const;
 
-  msgInputs_->DeclarePropertyWithUnit("vertex_x", "mm", vertexX_, "vertex x");
-  msgInputs_->DeclarePropertyWithUnit("vertex_y", "mm", vertexY_, "vertex y");
-  msgInputs_->DeclarePropertyWithUnit("vertex_z", "mm", vertexZ_, "vertex z");
+  private:
+    // All messengers
+    G4GenericMessenger* msgEvent_;
+    G4GenericMessenger* msgInputs_;
+    G4GenericMessenger* msgSupernova_;
+    G4GenericMessenger* msgSupernovaTiming_;
+    G4GenericMessenger* msgGeometry_;
 
-  // Declare all properties for msgSupernova
-  msgSupernova_->DeclareProperty("N_Ar39_Decays", nAr39Decays_,  "number of Ar39 decays");
-  msgSupernova_->DeclareProperty("N_Ar42_Decays", nAr42Decays_,  "number of Ar42 decays");
-  msgSupernova_->DeclareProperty("N_Kr85_Decays", nKr85Decays_,  "number of Kr85 decays");
-  msgSupernova_->DeclareProperty("N_Co60_Decays", nCo60Decays_,  "number of Co60 decays");
-  msgSupernova_->DeclareProperty("N_K40_Decays", nK40Decays_,  "number of K40 decays");
-  msgSupernova_->DeclareProperty("N_K42_Decays", nK42Decays_,  "number of K42 decays");
-  msgSupernova_->DeclareProperty("N_Bi214_Decays", nBi214Decays_,  "number of Bi214 decays");
-  msgSupernova_->DeclareProperty("N_Pb214_Decays", nPb214Decays_,  "number of Pb214 decays");
-  msgSupernova_->DeclareProperty("N_Po210_Decays", nPo210Decays_,  "number of Po210 decays");
-  msgSupernova_->DeclareProperty("N_Po214_Decays", nPo214Decays_,  "number of Po214 decays");
-  msgSupernova_->DeclareProperty("N_Po218_Decays", nPo218Decays_,  "number of Po218 decays");
-  msgSupernova_->DeclareProperty("N_Rn222_Decays", nRn222Decays_,  "number of Rn222 decays");
 
-  msgSupernova_->DeclarePropertyWithUnit("Event_Cutoff", "ns", eventCutoff_,  "window to simulate the times");
-  msgSupernova_->DeclarePropertyWithUnit("Event_Window", "ns", eventWindow_,  "window to simulate the times");
+  private:
+    // msgEvent variables
+    G4int         eventIDOffset_;
+    G4double      energyThreshold_;
 
-  // Declare all properties for msgSupernovaTiming
-  msgSupernovaTiming_->DeclareProperty("on", snTimingOn_, "turn on SupernovaTiming");
-  msgSupernovaTiming_->DeclareProperty("th2_name", th2Name_, "name of TH2");
+    // msgInputs variables
+    G4String      particleType_;
+    G4bool        decayAtTimeZero_;
+    G4bool        isotropic_;
+    G4bool        overrideVertexPosition_;
+    G4bool        printParticleInfo_;
+    G4String      inputFile_;
+    G4String      outputFile_;
+    G4String      marleyJson_;
+    G4String      generator_;
+    G4String      genieFormat_;
+    G4bool        multirun_;
+    G4ThreeVector momentumDirection_;
+    G4double      vertexX_;
+    G4double      vertexY_;
+    G4double      vertexZ_;
 
-  // Declare all properties for msgGeometry
-  msgGeometry_->DeclareProperty("use_hd_detector_configuration", useHDDetectorConfiguration_, "True if HD, false if VD");
-  msgGeometry_->DeclareProperty("detector_length", detectorLength_, "detector length");
-  msgGeometry_->DeclareProperty("detector_width", detectorWidth_, "detector width");
-  msgGeometry_->DeclareProperty("detector_height", detectorHeight_, "detector height");
-}
+    // msgSupernova variables
+    G4int         nAr39Decays_;
+    G4int         nAr42Decays_;
+    G4int         nKr85Decays_;
+    G4int         nCo60Decays_;
+    G4int         nK40Decays_;
+    G4int         nK42Decays_;
+    G4int         nBi214Decays_;
+    G4int         nPb214Decays_;
+    G4int         nPo210Decays_;
+    G4int         nPo214Decays_;
+    G4int         nPo218Decays_;
+    G4int         nRn222Decays_;
+    G4double      eventCutoff_;
+    G4double      eventWindow_;
 
-//-----------------------------------------------------------------------------
-void ConfigManager::PrintConfig() const
-{
-  G4cout << "EventAction -- Event_ID_Offset:    " << eventIDOffset_ << G4endl
-     << "EventAction -- Energy_Threshold:   " << energyThreshold_ << G4endl
-     << G4endl
-     << "Input -- Generator:                " << generator_ << G4endl
-     << "Input -- Genie Format:             " << genieFormat_ << G4endl
-     << "Input -- Particle_Type:            " << particleType_ << G4endl
-     << "Input -- Decay_At_Time_Zero:       " << decayAtTimeZero_ << G4endl
-     << "Input -- Isotropic:                " << isotropic_ << G4endl
-     << "Input -- Override_Vertex_Position: " << overrideVertexPosition_ << G4endl
-     << "Input -- Print_Particle_Info:      " << printParticleInfo_ << G4endl
-     << "Input -- Input_File:               " << inputFile_ << G4endl
-     << "Input -- Output_File:              " << outputFile_ << G4endl
-     << "Input -- MARLEY_json:              " << marleyJson_ << G4endl
-     << "Input -- Momentum_Direction:       " << momentumDirection_ << G4endl
-     << "Input -- Vertex_X:                 " << vertexX_/CLHEP::mm << " mm" << G4endl
-     << "Input -- Vertex_Y:                 " << vertexY_/CLHEP::mm << " mm" <<  G4endl
-     << "Input -- Vertex_Z:                 " << vertexZ_/CLHEP::mm << " mm" << G4endl
-     << "Input -- Multirun:                 " << multirun_ << G4endl
-     << G4endl
-     << "Supernova -- N_Ar39_Decays:  " << nAr39Decays_ << G4endl
-     << "Supernova -- N_Ar42_Decays:  " << nAr42Decays_ << G4endl
-     << "Supernova -- N_Kr85_Decays:  " << nKr85Decays_ << G4endl
-     << "Supernova -- N_Co60_Decays:  " << nCo60Decays_ << G4endl
-     << "Supernova -- N_K40_Decays:   " << nK40Decays_ << G4endl
-     << "Supernova -- N_K42_Decays:   " << nK42Decays_ << G4endl
-     << "Supernova -- N_Bi214_Decays: " << nBi214Decays_ << G4endl
-     << "Supernova -- N_Pb214_Decays: " << nPb214Decays_ << G4endl
-     << "Supernova -- N_Po210_Decays: " << nPo210Decays_ << G4endl
-     << "Supernova -- N_Po214_Decays: " << nPo214Decays_ << G4endl
-     << "Supernova -- N_Po218_Decays: " << nPo218Decays_ << G4endl
-     << "Supernova -- N_Rn222_Decays: " << nRn222Decays_ << G4endl
-     << "Supernova -- Event_Cutoff:   " << eventCutoff_/CLHEP::ns << " ns" << G4endl
-     << "Supernova -- Event_Window:   " << eventWindow_/CLHEP::ns << " ns" << G4endl
-     << G4endl
-     << "SupernovaTiming -- Supernova_Timing_On: " << snTimingOn_ << G4endl
-     << "SupernovaTiming -- TH2_Name:            " << th2Name_ << G4endl
-     << G4endl
-     << "Geometry -- Use_HD_Detector_Configuration: " << useHDDetectorConfiguration_ << G4endl
-     << "Geometry -- Detector_Length:               " << detectorLength_/CLHEP::m << " m" << G4endl
-     << "Geometry -- Detector_Width:                " << detectorWidth_/CLHEP::m << " m" << G4endl
-     << "Geometry -- Detector_Height:               " << detectorHeight_/CLHEP::m << " m" <<G4endl
-     << G4endl;
-}
+    // msgSupernovaTiming variables
+    G4bool        snTimingOn_;
+    G4String      th2Name_;
+
+    // msgGeometry variables
+    G4bool        useHDDetectorConfiguration_;
+    G4double      detectorLength_;
+    G4double      detectorWidth_;
+    G4double      detectorHeight_;
+};
+#endif

--- a/src/EventAction.h
+++ b/src/EventAction.h
@@ -12,9 +12,10 @@
 // QPix includes
 #include "AnalysisData.h"
 
-#include <G4UserEventAction.hh>
+// #include <G4UserEventAction.hh>
+#include </cvmfs/larsoft.opensciencegrid.org/products/geant4/v4_11_1_p01ba/Linux64bit+3.10-2.17-e20-prof/include/Geant4/G4UserEventAction.hh>
 
-
+class G4Event;
 class G4GenericMessenger;
 class AnalysisData;
 

--- a/src/GENIEManager.cpp
+++ b/src/GENIEManager.cpp
@@ -74,7 +74,7 @@ G4int GENIEManager::Initialize() {
   inputFile_ = ConfigManager::GetInputFile(); 
   particleType_ = ConfigManager::GetParticleType();
  
-  genieFormat_.toLower();
+  G4StrUtil::to_lower(genieFormat_);
 
   if (genieFormat_ == "rootracker" || genieFormat_ == "grootracker") {
     treeName_ = "gRooTracker";

--- a/src/MARLEYManager.cpp
+++ b/src/MARLEYManager.cpp
@@ -46,14 +46,14 @@ void MARLEYManager::Initialize()
 {
     if (!marley_json_.empty())
     {
-        std::cout << "Configuring MARLEY..." << std::endl;
+        G4cout << "Configuring MARLEY..." << G4endl;
         marley::JSONConfig marley_config(marley_json_);
         marley_generator_ = marley_config.create_generator();
     }
     else
     {
-        std::cout << "MARLEY configuration file not found!  Continuing..."
-                  << std::endl;
+        G4cout << "MARLEY configuration file not found!  Continuing..."
+                  << G4endl;
     }
 }
 

--- a/src/MCTruthManager.h
+++ b/src/MCTruthManager.h
@@ -62,6 +62,24 @@ class MCTruthManager {
 
         inline std::map< int, MCParticle * > GetMCParticleMap() const { return mc_particle_map_; }
 
+        //all particles of the event
+        std::vector<int>    *GetParticlesID()                    {return _particle_track_id;}
+        std::vector<int>    *GetParticlesParentID()              {return _particle_parent_track_id;}
+        std::vector<int>    *GetParticlesPDG()                   {return _particle_pdg_code;}
+        std::vector<double> *GetParticlesEnergy()                {return _particle_initial_energy;}
+        std::vector<double> *GetParticlesMass()                  {return _particle_mass;}
+        std::vector<double> *GetParticlesCharge()                {return _particle_charge;}
+        std::vector<int>    *GetParticlesProcess()               {return _particle_process_key;}
+        std::vector<double> *GetParticlesX()                     {return _particle_initial_x;}
+        std::vector<double> *GetParticlesY()                     {return _particle_initial_y;}
+        std::vector<double> *GetParticlesZ()                     {return _particle_initial_z;}
+        std::vector<double> *GetParticlesT()                     {return _particle_initial_t;}
+        std::vector<double> *GetParticlesPx()                    {return _particle_initial_px;}
+        std::vector<double> *GetParticlesPy()                    {return _particle_initial_py;}
+        std::vector<double> *GetParticlesPz()                    {return _particle_initial_pz;}
+        std::vector<int>    *GetParticlesNDaughters()            {return _particle_number_daughters;}
+        std::vector<std::vector<int>> *GetParticlesDaughtersIDs(){return _particle_daughter_track_ids;}
+
         typedef std::map<int,MCParticle*> MCParticleMap;
 
     private:
@@ -83,6 +101,24 @@ class MCTruthManager {
         // MC particle map
         // std::map< int, MCParticle > mc_particle_map_;
         std::map< int, MCParticle * > mc_particle_map_;
+
+        //all particles of the event
+        std::vector<int>    *_particle_track_id;
+        std::vector<int>    *_particle_parent_track_id;
+        std::vector<int>    *_particle_pdg_code;
+        std::vector<double> *_particle_initial_energy;
+        std::vector<double> *_particle_mass;
+        std::vector<double> *_particle_charge;
+        std::vector<int>    *_particle_process_key;
+        std::vector<double> *_particle_initial_x;
+        std::vector<double> *_particle_initial_y;
+        std::vector<double> *_particle_initial_z;
+        std::vector<double> *_particle_initial_t;
+        std::vector<double> *_particle_initial_px;
+        std::vector<double> *_particle_initial_py;
+        std::vector<double> *_particle_initial_pz;
+        std::vector<int>    *_particle_number_daughters;
+        std::vector<std::vector<int>> *_particle_daughter_track_ids;
 
 };
 

--- a/src/PhysicsList.cpp
+++ b/src/PhysicsList.cpp
@@ -1,0 +1,34 @@
+// -----------------------------------------------------------------------------
+//  G4Basic | G4Basic.cpp
+//
+//
+// -----------------------------------------------------------------------------
+
+#include "PhysicsList.h"
+
+#include <G4EmStandardPhysics_option4.hh>
+#include <G4DecayPhysics.hh>
+#include <G4RadioactiveDecayPhysics.hh>
+#include <G4StepLimiterPhysics.hh>
+#include <G4OpticalPhysics.hh>
+
+
+PhysicsList::PhysicsList(): G4VModularPhysicsList()
+{
+  RegisterPhysics(new G4EmStandardPhysics_option4());
+  RegisterPhysics(new G4DecayPhysics());
+  RegisterPhysics(new G4RadioactiveDecayPhysics());
+  RegisterPhysics(new G4StepLimiterPhysics());
+  RegisterPhysics(new G4OpticalPhysics());
+}
+
+
+PhysicsList::~PhysicsList()
+{
+}
+
+
+void PhysicsList::SetCuts()
+{
+  G4VUserPhysicsList::SetCuts();
+}

--- a/src/PhysicsList.h
+++ b/src/PhysicsList.h
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------------
+//  G4Basic | PhysicsList.h
+//
+//  
+// -----------------------------------------------------------------------------
+
+#ifndef PHYSICS_LIST_H
+#define PHYSICS_LIST_H
+
+#include <G4VModularPhysicsList.hh>
+
+
+class PhysicsList: public G4VModularPhysicsList
+{
+public:
+  PhysicsList();
+  virtual ~PhysicsList();
+  virtual void SetCuts();
+};
+
+#endif

--- a/src/PrimaryGeneration.cpp
+++ b/src/PrimaryGeneration.cpp
@@ -84,7 +84,7 @@ void PrimaryGeneration::GeneratePrimaries(G4Event* event)
   G4bool decay_at_time_zero_ = ConfigManager::GetDecayAtTimeZero();
   G4String particleType_ = ConfigManager::GetParticleType();
 
-  particleType_.toLower();
+  G4StrUtil::to_lower(particleType_);
 
 
   // get MC truth manager
@@ -158,6 +158,8 @@ void PrimaryGeneration::GeneratePrimaries(G4Event* event)
 
     double const kinetic_energy = particle_gun_->GetParticleEnergy() * CLHEP::MeV;
     double const energy = kinetic_energy + mass;
+    G4cout << "Mass = " << mass << G4endl;
+    G4cout << "Kinetic energy = " << kinetic_energy << G4endl;
 
     double const momentum = std::sqrt(energy*energy - mass*mass);
 
@@ -195,7 +197,7 @@ void PrimaryGeneration::GENIEGeneratePrimaries(G4Event* event)
   G4String particleType = ConfigManager::GetParticleType();
   G4ThreeVector momentumDirection_ = ConfigManager::GetMomentumDirection();
 
-  particleType.toLower();
+  G4StrUtil::to_lower(particleType);
 
   // Get MCTruthManager
   MCTruthManager * mc_truth_manager = MCTruthManager::Instance();

--- a/src/RunAction.cpp
+++ b/src/RunAction.cpp
@@ -54,9 +54,9 @@ void RunAction::BeginOfRunAction(const G4Run* g4run)
 
 
 
-    particleType_.toLower();
-    generator_.toLower();
-    genieFormat_.toLower();
+    G4StrUtil::to_lower(particleType_);
+    G4StrUtil::to_lower(generator_);
+    G4StrUtil::to_lower(genieFormat_);
 
     //ConfigManager::Print();
 
@@ -97,10 +97,10 @@ void RunAction::BeginOfRunAction(const G4Run* g4run)
         std::ostringstream ss;
         ss << std::setw(4) << std::setfill('0') << g4run->GetRunID();
         std::string runStr_(ss.str());
-        G4String parentPath_ = outputFile_(0, outputFile_.last('/'));
-        G4String baseName_ = outputFile_(outputFile_.last('/')+1, outputFile_.length());
-        G4String stem_ = baseName_(0, baseName_.last('.'));
-        G4String extension_ = baseName_(baseName_.last('.'), baseName_.length());
+        G4String parentPath_ = outputFile_.substr(0, outputFile_.rfind('/'));
+        G4String baseName_ = outputFile_.substr(outputFile_.rfind('/')+1, outputFile_.length());
+        G4String stem_ = baseName_.substr(0, baseName_.rfind('.'));
+        G4String extension_ = baseName_.substr(baseName_.rfind('.'), baseName_.length());
         
         root_output_path = parentPath_;
         root_output_path += "/";

--- a/src/Supernova.cpp
+++ b/src/Supernova.cpp
@@ -32,6 +32,8 @@ Supernova::Supernova()
     N_Bi214_Decays_(ConfigManager::GetNBi214Decays()),
     N_Pb214_Decays_(ConfigManager::GetNPb214Decays()),
     N_Po210_Decays_(ConfigManager::GetNPo210Decays()),
+    N_Po214_Decays_(ConfigManager::GetNPo214Decays()),
+    N_Po218_Decays_(ConfigManager::GetNPo218Decays()),
     N_Rn222_Decays_(ConfigManager::GetNRn222Decays())
 {
 }
@@ -118,7 +120,20 @@ void Supernova::Gen_Supernova_Background(G4Event* event)
         if (G4UniformRand() < 0.5){decay_time *= -1.0;}
         Generate_Radioisotope(event, 84, 210, decay_time, "APA"); //Po210 from APA
     }
-    
+        // Generate Po214
+    for (int ct=0; ct<N_Po214_Decays_; ct++)
+    {
+        decay_time = G4UniformRand() * Event_Window_;
+        if (G4UniformRand() < 0.5){decay_time *= -1.0;}
+        Generate_Radioisotope(event, 84, 214, decay_time, "Vol"); //Po214 from Volume
+    }    
+    // Generate Po218
+    for (int ct=0; ct<N_Po218_Decays_; ct++)
+    {
+        decay_time = G4UniformRand() * Event_Window_;
+        if (G4UniformRand() < 0.5){decay_time *= -1.0;}
+        Generate_Radioisotope(event, 84, 218, decay_time, "Vol"); //Po218 from Volume
+    }
     // Generate Rn222
     for (int ct=0; ct<N_Rn222_Decays_; ct++)
     {
@@ -296,5 +311,3 @@ void Supernova::Get_Detector_Dimensions(double detector_x_, double detector_y_, 
     detector_length_y_ = detector_y_;
     detector_length_z_ = detector_z_;
 }
-
-

--- a/src/Supernova.h
+++ b/src/Supernova.h
@@ -37,6 +37,8 @@ class Supernova {
         int N_Bi214_Decays_;
         int N_Pb214_Decays_;
         int N_Po210_Decays_;
+        int N_Po214_Decays_;
+	    int N_Po218_Decays_;
         int N_Rn222_Decays_;
 
         double decay_time;


### PR DESCRIPTION
This pull request fixes the following:

- Outdated packages on `setup_cvmfs.sh`
- Outdated syntax on macro files
- Deprecated modules which are not available on `Geant4 V4.11.1`
- Marley libraries not linked in `CMakeLists.txt`

Also, moving Physics list to a separate file in preparation for optical simulation modules (being done by Anissa).

This version will probably not work on `Geant4 version < 4.11.0`. It would probably be better to have it as a parallel branch/release, but I don't know how to do that.