### PR TITLE
Adding EventReset() to AnalysisData constructor

### DIFF
--- a/src/AnalysisData.cpp
+++ b/src/AnalysisData.cpp
@@ -20,6 +20,7 @@ AnalysisData::AnalysisData()
 {
 #ifdef G4ANALYSIS_USE
 #endif
+EventReset();
 }
 
 //-----------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,8 @@
 ##   * Creation date: 1 May 2020
 ## ---------------------------------------------------------
 
+include_directories(${Geant4_INCLUDE_DIRS})
+
 include_directories(${CMAKE_SOURCE_DIR}/src)
 
 SET(SRC   ActionInitialization.cpp


### PR DESCRIPTION
Adding EventReset() to AnalysisData constructor to properly initialize number_hits for the first event. 
Adding include_directories for those whose Geant4 library was not properly included in qpixg4.