### PR TITLE
Merging devlop changes to master branch

### DIFF
--- a/src/AnalysisData.cpp
+++ b/src/AnalysisData.cpp
@@ -20,6 +20,7 @@ AnalysisData::AnalysisData()
 {
 #ifdef G4ANALYSIS_USE
 #endif
+EventReset();
 }
 
 //-----------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,8 @@
 ##   * Creation date: 1 May 2020
 ## ---------------------------------------------------------
 
+include_directories(${Geant4_INCLUDE_DIRS})
+
 include_directories(${CMAKE_SOURCE_DIR}/src)
 
 SET(SRC   ActionInitialization.cpp


### PR DESCRIPTION
These are changes related to Geant4/10.7.x before we go ahead with Geant4/11.x. We solve the issue outlined here #26 by calling EventReset() in the AnalysisData constructor to properly initialize the number_hits variable. We also explicitly include the Geant4 directories in the CMakeLists.txt so globals.hh and other Geant4 headers can be found during build process.